### PR TITLE
Switch to bridge networking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN apk add --no-cache \
     bash \
     mtools \
     dosfstools \
+    socat \
+    tcpdump \
+    bridge-utils \
+    dnsmasq \
     && pip3 install --no-cache-dir --break-system-packages pywinrm \
     && rm -rf /var/cache/apk/* /tmp/* /root/.cache
 

--- a/scripts/build-vm-image.sh
+++ b/scripts/build-vm-image.sh
@@ -724,9 +724,9 @@ try:
         print("[DOCKER CONFIG] Removing any CLI flags from Docker service...")
         session.run_cmd('sc config docker binpath= "C:\\\\Windows\\\\system32\\\\dockerd.exe --run-service"')
         
-        # Set service to delayed start for better startup timing
-        print("[DOCKER CONFIG] Setting Docker service to delayed start...")
-        session.run_cmd('sc config docker start= delayed-auto')
+        # Set service to immediate start to eliminate 120s startup delay
+        print("[DOCKER CONFIG] Setting Docker service to immediate start...")
+        session.run_cmd('sc config docker start= auto')
         
         print("[DOCKER CONFIG] Docker configured to use daemon.json on startup")
     else:

--- a/unattend/autounattend.xml
+++ b/unattend/autounattend.xml
@@ -186,34 +186,39 @@
                     <Order>19</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>powershell -Command "echo 'Checking Docker service availability...' >> C:\docker-install.log; for(\$i=1; \$i -le 10; \$i++) { if(Get-Service Docker -ErrorAction SilentlyContinue) { echo 'Docker service found' >> C:\docker-install.log; Start-Service Docker *>> C:\docker-install.log 2>&amp;1; Set-Service Docker -StartupType Automatic *>> C:\docker-install.log 2>&amp;1; break } else { echo \"Attempt \$i: Docker service not ready, waiting...\" >> C:\docker-install.log; Start-Sleep -Seconds 30 } }"</CommandLine>
-                    <Description>Wait for and start Docker service</Description>
+                    <CommandLine>powershell -Command "echo 'Fixing Docker service startup type to eliminate 120s delay...' >> C:\docker-install.log; sc config docker start= auto *>> C:\docker-install.log 2>&amp;1; echo 'Docker service configured for immediate startup' >> C:\docker-install.log"</CommandLine>
+                    <Description>Fix Docker service startup type</Description>
                     <Order>20</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>powershell -Command "echo 'Checking Docker service availability...' >> C:\docker-install.log; for(\$i=1; \$i -le 10; \$i++) { if(Get-Service Docker -ErrorAction SilentlyContinue) { echo 'Docker service found' >> C:\docker-install.log; Start-Service Docker *>> C:\docker-install.log 2>&amp;1; break } else { echo \"Attempt \$i: Docker service not ready, waiting...\" >> C:\docker-install.log; Start-Sleep -Seconds 30 } }"</CommandLine>
+                    <Description>Wait for and start Docker service</Description>
+                    <Order>21</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>powershell -Command "echo 'Testing Docker installation...' >> C:\docker-install.log; docker version *>> C:\docker-install.log 2>&amp;1"</CommandLine>
                     <Description>Test Docker installation</Description>
-                    <Order>21</Order>
+                    <Order>22</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>powershell -Command "echo 'Adding Docker API firewall rule...' >> C:\docker-install.log; netsh advfirewall firewall add rule name='Docker API TCP' dir=in protocol=TCP localport=2376 action=allow *>> C:\docker-install.log 2>&amp;1"</CommandLine>
                     <Description>Add firewall rule for Docker API TCP port 2376</Description>
-                    <Order>22</Order>
+                    <Order>23</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>powershell -Command "echo 'Ensuring Docker auto-start configuration...' >> C:\docker-install.log; sc config docker start= auto *>> C:\docker-install.log 2>&amp;1; sc start docker *>> C:\docker-install.log 2>&amp;1; echo 'Final Docker service status:' >> C:\docker-install.log; sc query docker *>> C:\docker-install.log 2>&amp;1"</CommandLine>
-                    <Description>Ensure Docker service auto-starts and verify status</Description>
-                    <Order>23</Order>
+                    <CommandLine>powershell -Command "echo 'Verifying Docker service configuration...' >> C:\docker-install.log; sc query docker *>> C:\docker-install.log 2>&amp;1; Get-Service Docker *>> C:\docker-install.log 2>&amp;1"</CommandLine>
+                    <Description>Verify Docker service status</Description>
+                    <Order>24</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd /c "echo Docker installation complete > C:\docker-installed.txt"</CommandLine>
                     <Description>Mark Docker installation complete</Description>
-                    <Order>24</Order>
+                    <Order>25</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd /c "echo Setup complete > C:\setup-complete.txt"</CommandLine>
                     <Description>Mark Setup Complete</Description>
-                    <Order>25</Order>
+                    <Order>26</Order>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>


### PR DESCRIPTION
This sweet PR solves a few critical  and annoying issues:

## Bridge networking
Switches to prefer a bridged networking approach to ensure the inner vm can hit local network hosts as well as makes it so that the VM can be used for any port binding. Previously the developer needed to bind port `8888` to whatever the container might be running at internally and it was a bit of a mess.

Now the VM binds to the docker bridge itself so the linux host can now run any native windows container and directly bind the relevant port so `wcb` can be used for multiple apps as desired.

## Docker delayed start fix
The docker service was getting created with delayed start meaning windows was waiting for 2 minutes which was completely unnecessary so that is now resolved and wcb starts much faster.